### PR TITLE
oms_raw_public_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,37 @@ target/
 .df-credentials.json
 node_modules/
 package-lock.json
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/tools/cloud_functions/bq_table_snapshots/terraform/.terraform.lock.hcl
+++ b/tools/cloud_functions/bq_table_snapshots/terraform/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.4.0"
+  hashes = [
+    "h1:cJokkjeH1jfpG4QEHdRx0t2j8rr52H33A7C/oX73Ok4=",
+    "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
+    "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
+    "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
+    "zh:70dae36c176aa2b258331ad366a471176417a94dd3b4985a911b8be9ff842b00",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d8c8e3925f1e21daf73f85983894fbe8868e326910e6df3720265bc657b9c9c",
+    "zh:a032ec0f0aee27a789726e348e8ad20778c3a1c9190ef25e7cff602c8d175f44",
+    "zh:b8e50de62ba185745b0fe9713755079ad0e9f7ac8638d204de6762cc36870410",
+    "zh:c8ad0c7697a3d444df21ff97f3473a8604c8639be64afe3f31b8ec7ad7571e18",
+    "zh:df736c5a2a7c3a82c5493665f659437a22f0baf8c2d157e45f4dd7ca40e739fc",
+    "zh:e8ffbf578a0977074f6d08aa8734e36c726e53dc79894cfc4f25fadc4f45f1df",
+    "zh:efea57ff23b141551f92b2699024d356c7ffd1a4ad62931da7ed7a386aef7f1f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.84.0"
+  constraints = ">= 4.34.0"
+  hashes = [
+    "h1:fybaK74buTd4Ys2CUZm6jw7NXtSqtcLoW2jeNB4Ff2E=",
+    "zh:0b3e945fa76876c312bdddca7b18c93b734998febb616b2ebb84a0a299ae97c2",
+    "zh:1d47d00730fab764bddb6d548fed7e124739b0bcebb9f3b3c6aa247de55fb804",
+    "zh:29bff92b4375a35a7729248b3bc5db8991ca1b9ba640fc25b13700e12f99c195",
+    "zh:382353516e7d408a81f1a09a36f9015429be73ca3665367119aad88713209d9a",
+    "zh:78afa20e25a690d076eeaafd7879993ef9763a8a1b6762e2cbe42330464cc1fa",
+    "zh:8f6422e94de865669b33a2d9fb95a3e392e841988e890f7379a206e9d47e3415",
+    "zh:be5c7b52c893b971c860146aec643f7007f34430106f101eab686ed81eccbd26",
+    "zh:bfc37b641bf3378183eb3b8735554c3949a5cfaa8f76403d7eff38de1474b6d9",
+    "zh:c834f88dc8eb21af992871ed13a221015ae3b051aeca7386662071026f1546b4",
+    "zh:f3296c8c0d57dc28e23cf91717484264531655ac478d994584ebc73f70679471",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f8efe114ff4891776f48f7d2620b8d6963d3ddac6e42ce25bc761343da964c24",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/tools/cloud_functions/bq_table_snapshots/terraform/backend.tf
+++ b/tools/cloud_functions/bq_table_snapshots/terraform/backend.tf
@@ -14,7 +14,7 @@
 
 terraform {
   backend "gcs" {
-    bucket = "YOUR_TF_STATE_CLOUD_STORAGE_BUCKET"
+    bucket = "yardlink-terraform"
     prefix = "terraform/state"
   }
 }

--- a/tools/cloud_functions/bq_table_snapshots/terraform/function.tf
+++ b/tools/cloud_functions/bq_table_snapshots/terraform/function.tf
@@ -35,6 +35,11 @@ resource "google_bigquery_dataset" "dataset" {
   default_table_expiration_ms = 7776000000
 }
 
+moved {
+  from = google_bigquery_dataset.dataset["0"]
+  to   = google_bigquery_dataset.dataset
+}
+
 ##########################################
 #        GCS Bucket for CF code          #
 ##########################################

--- a/tools/cloud_functions/bq_table_snapshots/terraform/function.tf
+++ b/tools/cloud_functions/bq_table_snapshots/terraform/function.tf
@@ -31,6 +31,8 @@ resource "random_id" "bucket_prefix" {
 resource "google_bigquery_dataset" "dataset" {
   project    = var.storage_project_id
   dataset_id = var.target_dataset_name
+  location                    = "europe-west2"
+  default_table_expiration_ms = 7776000000
 }
 
 ##########################################
@@ -90,6 +92,7 @@ resource "google_cloudfunctions_function" "bq_backup_fetch_tables_names" {
   entry_point           = "main"
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.bq_backup_fetch_tables_names.name
+  service_account_email = "bq-data-snapshot@yardlink-data-prod.iam.gserviceaccount.com"
 
   environment_variables = {
     DATA_PROJECT_ID            = var.storage_project_id
@@ -127,6 +130,7 @@ resource "google_cloudfunctions_function" "bq_backup_create_snapshots" {
   entry_point           = "main"
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.bq_backup_create_snapshots.name
+  service_account_email = "bq-data-snapshot@yardlink-data-prod.iam.gserviceaccount.com"
 
   environment_variables = {
     BQ_DATA_PROJECT_ID = var.storage_project_id

--- a/tools/cloud_functions/bq_table_snapshots/terraform/terraform.tfvars
+++ b/tools/cloud_functions/bq_table_snapshots/terraform/terraform.tfvars
@@ -1,6 +1,6 @@
-project_id                = "YOUR_CLOUD_FUNCTIONS_PROJECT_ID"
-storage_project_id        = "YOUR_BIGQUERY_PROJECT_ID"
-source_dataset_name       = "YOUR_BIGQUERY_DATASET_ID"
-target_dataset_name       = "YOUR_SNAPSHOT_DATASET_ID"
-crontab_format            = "10 * * * *"
-seconds_before_expiration = 604800
+project_id                = "yardlink-data-prod"
+storage_project_id        = "yardlink-data-prod"
+source_dataset_name       = "oms_raw_public"
+target_dataset_name       = "oms_raw_public_history"
+crontab_format            = "0 0 * * 0"
+seconds_before_expiration = 5443200


### PR DESCRIPTION
@gmanninglive This is what i'm using to provision the 'snapsshotter'.

I can't see anything 'secret' in here so i think its all safe to store in our repo for now. 

These instructions basically allow you to send the terraform changes:

```
git clone https://github.com/Yardlynk/bigquery-utils.git

cd ./bigquery-utils/tools/cloud_functions/bq_table_snapshots/terraform

terraform init

terraform plan (this doesn't execute anything)

terraform apply 
```

It creates the following in out GCP account:

- Terraform details in an s3 bucket
- 2 Cloud functions 
- 1 Cloud Scheduler Job
- 2 Pub/Sub topics
- The new data set in BQ

Shout if you have thoughts or concerns

